### PR TITLE
Error handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,15 +84,20 @@ var Database = function (options) {
 				return allQueriesPromise;
 			})
 			.then(function () {
+				// note: disable further queries BEFORE running commit, because finally() runs in
+				// asynchronously AFTER commit and there might be queries in between - impossible to test
+				transactionComplete = true;
 				return Q.ninvoke(connection, "commit");
 			})
 			.catch(function (e) {
+				// note: disable further queries BEFORE running rollback, because finally() runs in
+				// asynchronously AFTER rollback and there might be queries in between - impossible to test
+				transactionComplete = true;
 				return Q.ninvoke(connection, "rollback").then(function () {
 					throw e; // rethrow!
 				});
 			})
 			.finally(function () {
-				transactionComplete = true;
 				connection.release(); // note: no clue how to assert this actually happened
 			});
 	};

--- a/index.js
+++ b/index.js
@@ -79,6 +79,7 @@ var Database = function (options) {
 				var allQueriesPromise = inTransactionFn(transactionScope);
 				if (!Q.isPromise(allQueriesPromise)) {
 					allQueriesPromise = Q.all(allQueries);
+					transactionComplete = true;
 				}
 				return allQueriesPromise;
 			})


### PR DESCRIPTION
Assume that when promise is returned from the user - they know what they're doing and handle errors themselves;
Assume that when no promise is returned by the user - we need to handle errors, i.e. rollback if any query fails;
Disable calling subsequent queries on transaction sooner, rather than later;
